### PR TITLE
add negative tests + parametrize check_email

### DIFF
--- a/src/clients/auth_client.py
+++ b/src/clients/auth_client.py
@@ -33,7 +33,6 @@ class AuthClient:
         }
         response = self.http.post("/auth/email_login", json=payload)
 
-        # сохраняем токен в http клиент, чтобы другие клиенты могли его использовать
         if response.status_code == 200:
             data = response.json()
             token = data.get("token")
@@ -74,7 +73,6 @@ class AuthClient:
         }
         response = self.http.post("/auth/login", json=payload)
 
-        # сохраняем токен в http клиент, чтобы другие клиенты могли его использовать
         if response.status_code == 200:
             data = response.json()
             token = data.get("token")

--- a/src/clients/http_base.py
+++ b/src/clients/http_base.py
@@ -1,30 +1,24 @@
 import allure
-import requests  # библиотека для HTTP-запросов
-from typing import Optional, Dict  # типы для удобства и читаемости
+import requests
+from typing import Optional, Dict
 
 
 class HttpBase:
-    # Конструктор — вызывается при создании объекта клиента
     def __init__(self, base_url: str, token: str = None):
         self.base_url = base_url  # базовый URL API (например: "https://stage.api.com")
         self.token = token  # токен пользователя, если он есть
 
-    # Метод для сборки заголовков
     def build_headers(self, headers: Optional[Dict] = None) -> Dict:
-        # Если передали headers → копируем их; если нет → создаём пустой словарь
         final_headers = headers.copy() if headers else {}
 
-        # Если клиент авторизован и есть токен → добавляем в заголовки
         if self.token:
             final_headers["X-Access-Token"] = self.token
 
-        # По умолчанию указываем, что отправляем JSON (если клиент этого не сделал раньше)
         final_headers.setdefault("Content-Type", "application/json")
 
-        # Возвращаем итоговый набор заголовков
         return final_headers
 
-    # Метод GET-запроса
+
     def get(self, path: str, params: Dict | None = None, headers: Dict | None = None):
         url = self.base_url + path
         final_headers = self.build_headers(headers)
@@ -39,7 +33,7 @@ class HttpBase:
 
             return response
 
-    # Метод POST-запроса
+
     def post(self, path: str, json: Dict | None = None, headers: Dict | None = None):
         url = self.base_url + path
         final_headers = self.build_headers(headers)

--- a/tests/api/auth/test_check_email_negative.py
+++ b/tests/api/auth/test_check_email_negative.py
@@ -1,0 +1,80 @@
+import pytest
+
+from tests.fixtures.auth_fixtures import TEST_IP, TEST_USER_AGENT, TEST_EMAIL
+
+# НЕПОЛНЫЙ JSON
+@pytest.mark.parametrize("payload,description", [
+    ({"ip": TEST_IP, "user_agent":TEST_USER_AGENT}, "Нет email"),
+    ({"email": TEST_EMAIL, "user_agent":TEST_USER_AGENT}, "Нет ip"),
+    ({"email": TEST_EMAIL, "ip": TEST_IP,}, "Нет user-agent"),
+    ({}, "Пустой JSON")
+])
+def test_check_email_missing_fields(auth_client, assert_response, payload, description):
+    resp = auth_client.http.post("/auth/check_email", json=payload)
+
+    assert_response(resp, expected=(400,401), msg=f"Отсутствуют обязательные поля: ({description})")
+
+
+
+# НЕВЕРНЫЕ ЗНАЧЕНИЯ ПОЛЕЙ
+@pytest.mark.parametrize("email,description", [
+    ("a",                   "слишком короткий"),
+    ("aaa",                 "нет домена"),
+    ("a@",                  "нет домена после @"),
+    ("aaa@aaa",             "нет точки в домене"),
+    ("aaa@aaa.",            "точка на конце"),
+    ("aaa@aaa,aaa",         "запятая вместо точки"),
+    ("😀😀😀",             "редкие символы - смайлики"),
+    ("a"*300 + "@test.com", "слишком длинный email"),
+
+    (123,                   "число вместо email"),
+    ({"value": 123},                 "объект вместо email"),
+    ([123],                 "список вместо email"),
+    (None,                  "null email"),
+    (False,                 "boolean-значение вместо email"),
+    ("",                    "пустой email"),
+])
+def test_check_email_invalid_email(auth_client, assert_response, email, description):
+    resp = auth_client.check_email(
+        email=email,
+        ip=TEST_IP,
+        user_agent=TEST_USER_AGENT
+    )
+
+    assert_response(resp, expected=(400,401), msg=f"Неверный формат email: ({description})")
+
+@pytest.mark.parametrize("ip,description", [
+    ("999.999.999.999", "невалидный ipv4"),
+    ("test",            "строка без формата ip"),
+    (123,               "число вместо ip"),
+    ({"value": 123},             "объект вместо ip"),
+    ([123],             "список вместо ip"),
+    (None,              "null ip"),
+    (False,             "boolean-значение вместо ip"),
+    ("",                "пустой ip")
+])
+def test_check_email_invalid_ip(auth_client, assert_response, ip, description):
+    resp = auth_client.check_email(
+        email=TEST_EMAIL,
+        ip=ip,
+        user_agent=TEST_USER_AGENT
+    )
+
+    assert_response(resp, expected=(400,401), msg=f"Неверный формат ip: ({description})")
+
+@pytest.mark.parametrize("user_agent,description", [
+    (123,       "число вместо user-agent"),
+    ({"value": 123},     "объект вместо user-agent"),
+    ([123],     "список вместо user-agent"),
+    (None,      "null user-agent"),
+    (False,     "boolean-значение вместо user-agent"),
+    ("",        "пустой user-agent"),
+])
+def test_check_email_invalid_user_agent(auth_client, assert_response, user_agent, description):
+    resp = auth_client.check_email(
+        email=TEST_EMAIL,
+        ip=TEST_IP,
+        user_agent=user_agent
+    )
+
+    assert_response(resp, expected=(400,401), msg=f"Неверный формат user-agent: ({description})")

--- a/tests/api/auth/test_login_email_negative.py
+++ b/tests/api/auth/test_login_email_negative.py
@@ -125,7 +125,7 @@ def test_login_email_wrong_password_dict(auth_client, session_id_email):
 
 def test_login_email_wrong_password_emoji(auth_client, session_id_email):
     resp = auth_client.login_email(
-        password="😀😀😀",
+        password="123123123😀😀😀",
         sessionId=session_id_email
     )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,15 @@
+import pytest
+
 pytest_plugins = [
     "tests.fixtures.auth_fixtures"
 ]
+
+@pytest.fixture
+def assert_response():
+    def _assert(resp, expected=(200,), msg=""):
+        assert resp.status_code in expected, (
+            f"{msg} Ожидали {expected}, "
+            f"но получили {resp.status_code}. Ответ: {resp.text}"
+        )
+    return _assert
 


### PR DESCRIPTION
## Что сделано
Добавлены негативные тесты для эндпоинта `/auth/check_email`:
- Проверка отсутствующих обязательных полей (email, ip, user_agent)
- Проверки неверных типов данных (int, bool, list, dict, None)
- Проверки некорректных форматов email и ip
- Параметризация тестов для сокращения дублирования

Также реализовано:
- Универсальная фикстура `assert_response` для единого формата проверок
- Структурирование тестов в отдельный файл `test_check_email_negative.py`

## Зачем сделано
- Покрытие максимального количества негативных сценариев
- Раннее выявление ошибок валидации на API
- Приведение проекта к стандарту промышленной автоматизации
- Подготовка к дальнейшему покрытию `/auth/email_login` и `/auth/phone_login`

## Что планируется дальше
- Добавить позитивные тесты check_email
- Добавить негативные тесты для email_login / phone_login
- Покрыть регистрацию (email / phone)
- Доработать общий клиент и константы для снижения дублирования