### PR TITLE
feat: add signup/confirm tests for email + negative cases

### DIFF
--- a/src/clients/auth_client.py
+++ b/src/clients/auth_client.py
@@ -142,6 +142,30 @@ class AuthClient:
 
         return parsed
 
+    def signup_email(self, email: str, password: str, currency_id: int, langAlias: str):
+        payload = {
+            "email": email,
+            "password": password,
+            "currency_id": currency_id,
+            "langAlias": langAlias
+        }
+        response = self.http.post("/auth/signUpEmail", json=payload)
+        parsed = self._parse(response, FastRegSignUpResponse)
+
+        return parsed
+
+    def confirm_email(self, session_id: str):
+        payload = {"session_id": session_id}
+        response = self.http.post("/auth/confirmEmail", json=payload)
+        parsed = self._parse(response, FastRegConfirmResponse)
+
+        # Если успешный ответ — устанавливаем токен в HttpBase
+        if isinstance(parsed, FastRegConfirmResponse):
+            self.http.token = parsed.token
+
+        return parsed
+
+
 
 
 

--- a/tests/api/auth/fast_reg/test_confirm_negative.py
+++ b/tests/api/auth/fast_reg/test_confirm_negative.py
@@ -1,0 +1,25 @@
+import pytest
+
+
+@pytest.mark.parametrize(
+    "session_id, description",
+    [
+        ("", "пустой sessionId"),
+        (" " * 5, "sessionId из пробелов"),
+        (123, "sessionId = int"),
+        (True, "sessionId = boolean"),
+        (None, "sessionId = null"),
+        (["123123123123123"], "sessionId = список"),
+        ({"id": "123123123123"}, "sessionId = объект"),
+        ("😀😀😀", "sessionId = emoji"),
+        ("1" * 5000, "слишком длинный sessionId"),
+        ("00000000-0000-0000-0000-000000000000", "несуществующий sessionId"),
+        ("not-a-uuid", "не uuid, но строка")
+    ])
+def test_confirm_phone_negative(auth_client, session_id, description, assert_response):
+    resp = auth_client.confirm_phone(session_id=session_id)
+    assert_response(
+        resp,
+        expected=(400, 500),
+        msg=f"Неверное значение sessionId: {description}",
+    )

--- a/tests/api/auth/fast_reg/test_signUpEmail.py
+++ b/tests/api/auth/fast_reg/test_signUpEmail.py
@@ -1,0 +1,3 @@
+def test_fastreg_positive(fastreg_phone_user):
+    resp = fastreg_phone_user.http.get("/user/me")
+    assert resp.status_code == 200

--- a/tests/api/auth/fast_reg/test_signUpEmail_negative.py
+++ b/tests/api/auth/fast_reg/test_signUpEmail_negative.py
@@ -1,0 +1,260 @@
+import pytest
+
+from tests.fixtures.auth_fixtures import (
+    TEST_REGISTER_PASSWORD,
+    TEST_IP,
+    TEST_PLATFORM,
+    TEST_USER_AGENT, random_phone, random_email,
+)
+
+# ==========================================================
+# 1. ОТСУТСТВУЮЩИЕ ПОЛЯ (STRUCTURE)
+# ==========================================================
+
+@pytest.mark.parametrize(
+    "use_email, use_password, use_currency_id, use_langAlias, description",
+    [
+        (False, False, False, False, "пустой JSON"),
+        (False, True, True, True, "нет email"),
+        (True, False, True, True, "нет password"),
+        (True, True, False, True, "нет currency_id"),
+        (True, True, True, False, "нет langAlias"),
+    ],
+)
+def test_signUpEmail_missing_fields(
+    auth_client,
+    use_email,
+    use_password,
+    use_currency_id,
+    use_langAlias,
+    description,
+    random_email,
+    assert_response
+):
+
+    # Собираем payload согласно пересечению параметров
+    payload = {}
+    if use_email: payload["email"] = random_email
+    if use_password: payload["password"] = TEST_REGISTER_PASSWORD
+    if use_currency_id: payload["currency_id"] = 4
+    if use_langAlias: payload["langAlias"] = "en"
+
+    # Передаём как именованные аргументы — signup_email сам соберёт payload
+    resp = auth_client.http.post("/auth/signUpEmail", json=payload)
+
+    assert_response(
+        resp,
+        expected=(400, 500),
+        msg=f"Отсутствуют обязательные поля: {description}"
+    )
+
+
+# ==========================================================
+# 2. НЕВАЛИДНЫЙ password
+# ==========================================================
+
+@pytest.mark.parametrize(
+    "password, description",
+    [
+        ("", "пустой password"),
+        (" " * 5, "password из пробелов"),
+        (123456, "password = int"),
+        (None, "password = null"),
+        (["123"], "password = список"),
+        ({"p": "123"}, "password = объект"),
+        ("1" * 5000, "слишком длинный password"),
+    ],
+)
+def test_signUpEmail_invalid_password(
+    auth_client,
+    random_email,
+    password,
+    description,
+    assert_response
+):
+
+    payload = {
+        "email": random_email,
+        "currency_id": 4,
+        "langAlias": "en",
+        "password": password,
+    }
+
+    resp = auth_client.http.post("/auth/signUpEmail", json=payload)
+
+    assert_response(
+        resp,
+        expected=(400, 500),
+        msg=f"Неверное значение password: {description}",
+    )
+
+# ==========================================================
+# 3. НЕВЕРНЫЕ ТИПЫ email (int, bool, list, dict) → 500
+# ==========================================================
+
+@pytest.mark.parametrize(
+    "email, description",
+    [
+        (123456, "email = int"),
+        (True, "email = boolean"),
+        (None, "email = null"),
+        (["aaa@bbb.cc"], "email = список"),
+        ({"email": "aaa@bbb.cc"}, "email = объект"),
+    ],
+)
+def test_signUpEmail_invalid_email_type(
+    auth_client,
+    email,
+    description,
+    assert_response
+):
+
+    payload = {
+        "email": email,
+        "password": TEST_REGISTER_PASSWORD,
+        "currency_id": 4,
+        "langAlias": "en",
+    }
+
+    resp = auth_client.http.post("/auth/signUpEmail", json=payload)
+
+    assert_response(
+        resp,
+        expected=(400, 500),
+        msg=f"Неверный тип email: {description}",
+    )
+
+# ==========================================================
+# 4. НЕВЕРНЫЕ ФОРМАТЫ email (string, но невалидные) → 400
+# ==========================================================
+
+INVALID_EMAIL_FORMATS = [
+    ("aaa", "нет @"),
+    ("aaa@", "нет домена"),
+    ("@aaa", "нет имени"),
+    ("aaa@bbb", "нет зоны (.com, .ru, .kz)"),
+    ("aaa@bbb.", "пустая зона"),
+    ("aaa bbb@ccc.com", "пробел в email"),
+    ("аааа@bbb.com", "кириллица"),
+    ("😀😀😀@mail.com", "эмодзи в имени"),
+    ("aaa@😀😀😀.com", "эмодзи в домене"),
+    ("aaa@@ccc.com", "двойной @"),
+    ("aaa@c,om", "запятая в домене"),
+    ("aaa@c.om.", "точка в конце"),
+    ("aaa@bbb..com", "двойная точка"),
+    ("", "пустая строка"),
+]
+
+@pytest.mark.parametrize("email, description", INVALID_EMAIL_FORMATS)
+def test_signUpEmail_invalid_email_format(
+    auth_client,
+    email,
+    description,
+    assert_response
+):
+
+    payload = {
+        "email": email,
+        "password": TEST_REGISTER_PASSWORD,
+        "currency_id": 4,
+        "langAlias": "en",
+    }
+
+    resp = auth_client.http.post("/auth/signUpEmail", json=payload)
+
+    assert_response(
+        resp,
+        expected=(400, 500),  # по доке должно быть 400, но backend может дать 500
+        msg=f"Неверный формат email: {description}",
+    )
+
+# ==========================================================
+# 5. НЕВАЛИДНЫЕ currency_id
+# ==========================================================
+
+@pytest.mark.parametrize(
+    "currency_id, description",
+    [
+        ("4", "currency_id = string"),     # строка вместо числа
+        (None, "currency_id = null"),
+        (True, "currency_id = boolean"),
+        (3.14, "currency_id = float"),
+        (["4"], "currency_id = список"),
+        ({"id": 4}, "currency_id = объект"),
+
+        (-1, "currency_id отрицательное"),
+        (0, "currency_id = 0"),
+        (9999, "currency_id слишком большое"),
+        (10**50, "currency_id крайне большое число"),
+    ]
+)
+def test_signUpEmail_invalid_currency_id(
+    auth_client,
+    random_email,
+    currency_id,
+    description,
+    assert_response,
+):
+
+    payload = {
+        "email": random_email,
+        "password": TEST_REGISTER_PASSWORD,
+        "currency_id": currency_id,
+        "langAlias": "en",
+    }
+
+    resp = auth_client.http.post("/auth/signUpEmail", json=payload)
+
+    assert_response(
+        resp,
+        expected=(400, 500),
+        msg=f"Неверное значение currency_id: {description}",
+    )
+
+# ==========================================================
+# 6. НЕВАЛИДНЫЙ langAlias
+# ==========================================================
+
+@pytest.mark.parametrize(
+    "langAlias, description",
+    [
+        (123, "langAlias = int"),
+        (True, "langAlias = boolean"),
+        (None, "langAlias = null"),
+        (["en"], "langAlias = список"),
+        ({"lang": "en"}, "langAlias = объект"),
+
+        ("", "langAlias пустой"),
+        (" ", "langAlias пробел"),
+        ("EN", "верхний регистр"),
+        ("e", "слишком короткий"),
+        ("english", "слишком длинный текст"),
+        ("рус", "кириллица"),
+        ("😀😀😀", "эмодзи"),
+        ("xx", "неизвестная локаль"),
+        ("zzz", "невалидная зона локали"),
+    ]
+)
+def test_signUpEmail_invalid_langAlias(
+    auth_client,
+    random_email,
+    langAlias,
+    description,
+    assert_response,
+):
+
+    payload = {
+        "email": random_email,
+        "password": TEST_REGISTER_PASSWORD,
+        "currency_id": 4,
+        "langAlias": langAlias,
+    }
+
+    resp = auth_client.http.post("/auth/signUpEmail", json=payload)
+
+    assert_response(
+        resp,
+        expected=(400, 500),
+        msg=f"Неверное значение langAlias: {description}",
+    )
+

--- a/tests/fixtures/auth_fixtures.py
+++ b/tests/fixtures/auth_fixtures.py
@@ -215,6 +215,38 @@ def fastreg_phone_user(auth_client, fastreg_phone_session_id):
     return auth_client
 
 
+@pytest.fixture
+def fastreg_email_session_id(auth_client, random_email):
+    response = auth_client.signup_email(
+        email=random_email,
+        password=TEST_REGISTER_PASSWORD,
+        currency_id=4,
+        langAlias="en"
+    )
+
+    # Новая проверка: response — это Pydantic модель
+    assert isinstance(response, FastRegSignUpResponse), (
+        f"signUp failed: {response}"
+    )
+
+    return response.session_id
+
+
+@pytest.fixture
+def fastreg_email_user(auth_client, fastreg_email_session_id):
+    response = auth_client.confirm_email(
+        session_id=fastreg_email_session_id
+    )
+
+    # Новая проверка: response — это Pydantic модель
+    assert isinstance(response, FastRegConfirmResponse), f"confirm failed: {response}"
+
+    assert response.token, "confirm не вернул token"
+
+    assert auth_client.http.token, "Token not set in AuthClient"
+
+    return auth_client
+
 # ============================================================
 # RANDOM DATA
 # ============================================================


### PR DESCRIPTION
Добавлено полное покрытие негативных сценариев для fast registration по email (signUpEmail):
- отсутствие обязательных полей
- неверные типы email
- неверный формат email
- неверные типы password
- неверные значения password
- неверные типы currency_id
- неверные значения currency_id
- неверные значения langAlias
- структурный рефактор негативных тестов